### PR TITLE
Encode * and @ in canonical request path for AWS V4 signature algorithm

### DIFF
--- a/jets3t/src/main/java/org/jets3t/service/utils/SignatureUtils.java
+++ b/jets3t/src/main/java/org/jets3t/service/utils/SignatureUtils.java
@@ -643,6 +643,10 @@ public class SignatureUtils {
                 result.append(ch);
             } else if (ch == '/') {
                 result.append(encodeSlash ? "%2F" : ch);
+            } else if (ch == '*') {
+                result.append("%2A");
+            } else if (ch == '@') {
+                result.append("%40");
             } else {
                 String hex = RestUtils.encodeUrlString(String.valueOf(ch));
                 result.append(hex);

--- a/jets3t/src/test/java/org/jets3t/service/utils/SignatureUtilsTest.java
+++ b/jets3t/src/test/java/org/jets3t/service/utils/SignatureUtilsTest.java
@@ -96,4 +96,14 @@ public class SignatureUtilsTest {
                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                 signature);
     }
+
+    @Test
+    public void testAwsV4EncodeURIWithSpecialHandlingCharacters() {
+        final String uri = "/ *@.pdf";
+        final String expectEncoded = "/%20%2A%40.pdf";
+        final String encoded = SignatureUtils.awsV4EncodeURI(uri, false);
+
+        assertEquals(expectEncoded, encoded);
+    }
+
 }


### PR DESCRIPTION
Ran into errors with AWS signature version 4 enabled and traced it back to `*` and `@` _not_ being URI encoded when they appear in the object key.  Based on the specification https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html `*` and `@` should be encoded and doing so resolved the signature errors.